### PR TITLE
Fix PlanItemTest.java

### DIFF
--- a/src/test/java/cz/upce/fei/inptp/zz/planner/PlanItemTest.java
+++ b/src/test/java/cz/upce/fei/inptp/zz/planner/PlanItemTest.java
@@ -21,14 +21,14 @@ public class PlanItemTest {
     @Test(expected = RuntimeException.class)
     public void testAddOrderForNullValue() {
         Order order = null;
-        PlanItem planItem = new PlanItem(new Vehicle("idVehicle", 4, VehicleType.Medium), new Driver("idDriver"));
+        PlanItem planItem = new PlanItem(new Vehicle("idVehicle", 4, VehicleType.Medium, 125), new Driver("idDriver"));
         planItem.addOrder(order);
     }
     
     @Test
     public void testAddOrderForNonNullValue() {
         Order order = new Order("A", "B", 4);
-        PlanItem planItem = new PlanItem(new Vehicle("idVehicle", 4, VehicleType.Medium), new Driver("idDriver"));
+        PlanItem planItem = new PlanItem(new Vehicle("idVehicle", 4, VehicleType.Medium, 298), new Driver("idDriver"));
         planItem.addOrder(order);
         List<Order> list = planItem.getOrders();
         assertEquals(order, list.get(0));


### PR DESCRIPTION
File PlanItemTest.java was fixed. There was compilation error because of creating of object according to the old constructor.